### PR TITLE
added support for passing a bearer token header to Graphite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- nothing
+### Added
+- --auth param allows authentication by bearer token
 
 ## [0.0.5] - 2015-08-05
 ### Changed


### PR DESCRIPTION
...via a new -a / --auth option.

This allows access to Graphite to be restricted to those with a valid bearer token, rather than having to be open to all. 

Also refactored the option-handling and output-formatting to separate methods, for clarity.
