### PR TITLE
encode URI to allow for graphite functions

### DIFF
--- a/bin/check-graphite-stats.rb
+++ b/bin/check-graphite-stats.rb
@@ -121,7 +121,7 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
   def run
     body =
       begin
-        uri = URI("http://#{config[:host]}/render?format=json&target=#{config[:target]}&from=#{config[:period]}")
+        uri = URI.parse(URI.encode("http://#{config[:host]}/render?format=json&target=#{config[:target]}&from=#{config[:period]}"))
         res = Net::HTTP.get_response(uri)
         res.body
       rescue => e


### PR DESCRIPTION
This will allow us to send graphite functions as params (`exclude(my.stat.*.*, "count")` for example). 
