### PR TITLE
Complex target

### DIFF
--- a/bin/check-graphite.rb
+++ b/bin/check-graphite.rb
@@ -46,6 +46,12 @@ class Graphite < Sensu::Plugin::Check::CLI
          long: '--target TARGET',
          required: true
 
+  option :complex_target,
+         description: 'Allows complex targets which contain functions. Disables splitting on comma.',
+         short: '-x',
+         long: '--complex_target',
+         default: false
+
   option :period,
          description: 'The period back in time to extract from Graphite and compare with. Use 24hours,2days etc, same format as in Graphite',
          short: '-p PERIOD',
@@ -457,8 +463,8 @@ class Graphite < Sensu::Plugin::Check::CLI
     [warnings, criticals, fatal]
   end
 
-  def run
-    targets = config[:target].split(',')
+  def run # rubocop:disable Metrics/AbcSize
+    targets = config[:complex_target] ? [config[:target]] : config[:target].split(',')
     @period = config[:period]
     critical_errors = []
     warnings = []

--- a/bin/check-graphite.rb
+++ b/bin/check-graphite.rb
@@ -463,7 +463,7 @@ class Graphite < Sensu::Plugin::Check::CLI
     [warnings, criticals, fatal]
   end
 
-  def run # rubocop:disable Metrics/AbcSize
+  def run # rubocop:disable AbcSize
     targets = config[:complex_target] ? [config[:target]] : config[:target].split(',')
     @period = config[:period]
     critical_errors = []


### PR DESCRIPTION
Add --complex_target / -x to allow complex targets which contain functions with multiple parameters. This disables splitting on the comma.

Example showing how this can be used to limit alerts based on uptime:

```
plugins/graphite/graphite.rb -h graphite.example -t 'nonNegativeDerivative(useSeriesAbove(example.server*.uptime, 1200, "uptime", "requests"))' -a 1,1 -g -x
Graphite CRITICAL: The average value of metric nonNegativeDerivative(example.server1.requests) is 372162.7358490566 that is greater than allowed average of 1
The average value of metric nonNegativeDerivative(example.server2.requests) is 220345.547008547 that is greater than allowed average of 1
```

This change puts the branch checking one above the rubocop limit. Looking at the run routine changing it to be smaller is probably not a minor change and several of the conditions are very basic and easy to follow, so I'm adding a rubocop override instead.
