### PR TITLE
Fix comparison of number against array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- nothing
+### Fixed
+- fix comparison of number against array in --last.
+- improve wording of --last help text.
 
 ## [0.0.7] - 2015-09-29
 ### Added

--- a/bin/check-graphite.rb
+++ b/bin/check-graphite.rb
@@ -428,14 +428,13 @@ class Graphite < Sensu::Plugin::Check::CLI
   end
 
   def check_last(target, max_values)
-    last_targets = last_graphite_metric target
+    last_targets = last_graphite_value target
     return [[], [], []] unless last_targets
     warnings = []
     criticals = []
     fatal = []
     # #YELLOW
-    last_targets.each do |target_name, last|
-      last_value = last.first
+    last_targets.each do |target_name, last_value|
       unless last_value.nil?
         # #YELLOW
         %w(fatal error warning).each do |type|

--- a/bin/check-graphite.rb
+++ b/bin/check-graphite.rb
@@ -443,7 +443,7 @@ class Graphite < Sensu::Plugin::Check::CLI
           var1 = config[:greater_than] ? last_value : max_value.to_f
           var2 = config[:greater_than] ? max_value.to_f : last_value
           if var1 > var2
-            text = "The metric #{target_name} is #{last_value} that is #{greater_less} than max allowed #{max_value}"
+            text = "The metric #{target_name} is #{last_value} that is #{greater_less} than last allowed #{max_value}"
             case type
             when 'warning'
               warnings << text


### PR DESCRIPTION
_last_graphite_metric_ returns the last datapoint as a list of up to count datapoint `[value, timeseries]` pairs; where count is 1. Thus we get following back: `{target => [[value, timestamp]], ...}`

the code was treating this instead as a single datapoint pair, not a list of datapoint pairs, resulting in checking _number_ < _list_

instead use _last_graphite_value_ which returns the mean of all values returned by _last_graphite_metric_ as a single value, giving us instead `{target => mean, ...}` where again count=1
