### PR TITLE
Use the whole client name as hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 - nothing
 
+## [1.0.0] - 2016-01-20
+### Changed
+- Use the whole client name as hostname for graphite measurement
+
 ## [0.0.7] - 2015-09-29
 ### Added
 - add -r option (Reverse the warning/crit scale (if value is less than instead of greater than)) to check-graphite-stats.rb

--- a/bin/handler-graphite-occurrences.rb
+++ b/bin/handler-graphite-occurrences.rb
@@ -12,7 +12,7 @@ class GraphiteOccurrences < Sensu::Handler
   def filter; end
 
   def handle
-    hostname = @event['client']['name'].split('.').first
+    hostname = @event['client']['name']
     # #YELLOW
     check_name = @event['check']['name'].gsub(%r{[ \.]}, '_')
     value = @event['action'] == 'create' ? @event['occurrences'] : 0

--- a/lib/sensu-plugins-graphite/version.rb
+++ b/lib/sensu-plugins-graphite/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsGraphite
   module Version
-    MAJOR = 0
+    MAJOR = 1
     MINOR = 0
-    PATCH = 7
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Enable detailed graphite namespacing by using the full client name as
part of the graphite measurement name.
