### PR TITLE
Proper error handling in handlers & disable filter for graphite-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Disable filtering for handler-graphite-status.rb
+### Fixed
+- Error handling in graphite handlers
 
 ## [2.0.0] - 2016-06-21
 ### Added

--- a/bin/check-graphite-stats.rb
+++ b/bin/check-graphite-stats.rb
@@ -142,7 +142,7 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
     data.each do |metric|
       s, msg = danger(metric)
 
-      message += "#{msg} " unless s == 0
+      message += "#{msg} " unless s.zero?
       status = s unless s < status
     end
 

--- a/bin/handler-graphite-notify.rb
+++ b/bin/handler-graphite-notify.rb
@@ -21,8 +21,8 @@ class Resolve < Sensu::Handler
       graphite.push_to_graphite do |graphite_socket|
         graphite_socket.puts message
       end
-    rescue ETIMEDOUT
-      error_msg = "Can't connect to #{settings['graphite_notify']['host']}:#{port} and send message #{message}'"
+    rescue => e
+      error_msg = "Can't connect to #{settings['graphite_notify']['host']}:#{port} and send message #{message}: #{e}'"
       raise error_msg
     end
   end

--- a/bin/handler-graphite-status.rb
+++ b/bin/handler-graphite-status.rb
@@ -11,6 +11,9 @@ require 'sensu-handler'
 require 'simple-graphite'
 
 class Resolve < Sensu::Handler
+  # override filters from Sensu::Handler. not appropriate for metric handlers
+  def filter; end
+
   def handle
     port = settings['graphite_notify']['port'] ? settings['graphite_notify']['port'].to_s : '2003'
     graphite = Graphite.new(host: settings['graphite_notify']['host'], port: port)
@@ -22,8 +25,8 @@ class Resolve < Sensu::Handler
       graphite.push_to_graphite do |graphite_socket|
         graphite_socket.puts message
       end
-    rescue ETIMEDOUT
-      error_msg = "Can't connect to #{settings['graphite_notify']['host']}:#{port} and send message #{message}'"
+    rescue => e
+      error_msg = "Can't connect to #{settings['graphite_notify']['host']}:#{port} and send message #{message}: #{e}'"
       raise error_msg
     end
   end


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 

This fixes runtime exceptions when we get another error (not timeout). It's also fixes issue with status handler filtering out metrics for graphite.  
