### PR TITLE
Exit with zero datapoints message if no datapoints exist

### DIFF
--- a/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
@@ -87,17 +87,17 @@ module SensuPluginsGraphite
             json_data = JSON.parse(@raw_data)
             format_output(json_data)
           rescue OpenURI::HTTPError
-            raise ProxyError.new('Failed to connect to Graphite server')
+            raise ProxyError, 'Failed to connect to Graphite server'
           rescue NoMethodError, JSON::ParserError
-            raise ProxyError.new('No data for time period and/or target')
+            raise ProxyError, 'No data for time period and/or target'
           rescue Errno::ECONNREFUSED
-            raise ProxyError.new('Connection refused when connecting to Graphite server')
+            raise ProxyError, 'Connection refused when connecting to Graphite server'
           rescue Errno::ECONNRESET
-            raise ProxyError.new('Connection reset by peer when connecting to Graphite server')
+            raise ProxyError, 'Connection reset by peer when connecting to Graphite server'
           rescue EOFError
-            raise ProxyError.new('End of file error when reading from Graphite server')
+            raise ProxyError, 'End of file error when reading from Graphite server'
           rescue => e
-            raise ProxyError.new("An unknown error occurred: #{e.inspect}")
+            raise ProxyError, "An unknown error occurred: #{e.inspect}"
           end
         end
       end

--- a/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
@@ -65,6 +65,7 @@ module SensuPluginsGraphite
 
       def output_line(raw)
         raw['datapoints'].delete_if { |v| v.first.nil? }
+        unknown 'No data for time period and/or target' if raw['datapoints'].empty?
         target = raw['target']
         data = raw['datapoints'].map(&:first)
         start = raw['datapoints'].first.last

--- a/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
+++ b/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb
@@ -86,18 +86,18 @@ module SensuPluginsGraphite
             @raw_data = handle.gets
             json_data = JSON.parse(@raw_data)
             format_output(json_data)
-            rescue OpenURI::HTTPError => e
-              raise ProxyError.new('Failed to connect to Graphite server')
-            rescue NoMethodError, JSON::ParserError => e
-              raise ProxyError.new('No data for time period and/or target')
-            rescue Errno::ECONNREFUSED => e
-              raise ProxyError.new('Connection refused when connecting to Graphite server')
-            rescue Errno::ECONNRESET => e
-              raise ProxyError.new('Connection reset by peer when connecting to Graphite server')
-            rescue EOFError => e
-              raise ProxyError.new('End of file error when reading from Graphite server')
-            rescue => e
-              raise ProxyError.new("An unknown error occurred: #{e.inspect}")
+          rescue OpenURI::HTTPError
+            raise ProxyError.new('Failed to connect to Graphite server')
+          rescue NoMethodError, JSON::ParserError
+            raise ProxyError.new('No data for time period and/or target')
+          rescue Errno::ECONNREFUSED
+            raise ProxyError.new('Connection refused when connecting to Graphite server')
+          rescue Errno::ECONNRESET
+            raise ProxyError.new('Connection reset by peer when connecting to Graphite server')
+          rescue EOFError
+            raise ProxyError.new('End of file error when reading from Graphite server')
+          rescue => e
+            raise ProxyError.new("An unknown error occurred: #{e.inspect}")
           end
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes. Currently check crashes if no datapoints left after the nil values cleansing.

Example:

```
Check failed to run: undefined method `last' for nil:NilClass, ["/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb:73:in `output_line'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb:61:in `block in format_output'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb:57:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb:57:in `format_output'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/lib/sensu-plugins-graphite/graphite_proxy/proxy.rb:97:in `retrieve_data!'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-graphite-2.0.0/bin/check-graphite-data.rb:61:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.2/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```
when raw['datapoints']:
```
[[nil, 1482283890], [nil, 1482283905], [nil, 1482283920], [nil, 1482283935]]
```

**What has changed?**
I've added additional check if datapoint is not nil

#### Known Compatablity Issues
No compatablity issues