### PR TITLE
Remove ternary true : false

### DIFF
--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -26,7 +26,7 @@ class GraphiteEvent < Sensu::Handler
     uri          = URI.parse(uri)
     req          = Net::HTTP::Post.new(uri.path)
     sock         = Net::HTTP.new(uri.host, uri.port)
-    sock.use_ssl = uri.scheme == 'https' ? true : false
+    sock.use_ssl = uri.scheme == 'https'
     req.body     = body
 
     req.basic_auth(uri.user, uri.password) if uri.user


### PR DESCRIPTION
Adding a ternary to something that returns a boolean is redundant:

```ruby
[1] pry(main)> true == true
=> true
[2] pry(main)> true == true ? true : false
=> true
[3] pry(main)> true == false ? true : false
=> false
[4] pry(main)> true == false
=> false
```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

