### PR TITLE
Fix duplicate short option in check-graphite.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Disable filtering for handler-graphite-status.rb
 ### Fixed
 - Error handling in graphite handlers
+- Duplicate short option in check-graphite.rb
 
 ## [2.0.0] - 2016-06-21
 ### Added

--- a/bin/check-graphite.rb
+++ b/bin/check-graphite.rb
@@ -67,14 +67,14 @@ class Graphite < Sensu::Plugin::Check::CLI
 
   option :acceptable_diff_percentage,
          description: 'The acceptable diff from max values in percentage, used in check_function_increasing',
-         short: '-d ACCEPTABLE_DIFF_PERCENTAGE',
+         short: '-D ACCEPTABLE_DIFF_PERCENTAGE',
          long: '--acceptable_diff_percentage ACCEPTABLE_DIFF_PERCENTAGE',
          default: 0
 
   option :check_function_increasing,
          description: 'Check that value is increasing or equal over time (use acceptable_diff_percentage if it should allow to be lower)',
          short: '-i',
-         long: '--check_function_decreasing',
+         long: '--check_function_increasing',
          default: false,
          boolean: true
 


### PR DESCRIPTION
## Pull Request Checklist

No existing issue

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

`-d` short option is used for 2 different options (`acceptable_diff_percentage` and `data_points`) which prevent using `acceptable_diff_percentage` in `check-graphite.rb`. This patch replaces `-d` with `-D`which is an unused letter.

#### Known Compatablity Issues

No BC break as a `check-graphite.rb -d` previously referred to the `data_points` as it was defined later in the options definitions.
