### PR TITLE
Updated the minimum version of sensu-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Fixed
-- Updated the minimum version of sensu-plugin to v2.0
+### Breaking Change
+- bumped dependency of `sensu-plugin` to 2.x you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)
 
 ## [2.3.0] - 2017-10-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Updated the minimum version of sensu-plugin to v2.0
 
 ## [2.3.0] - 2017-10-19
 ### Added

--- a/sensu-plugins-graphite.gemspec
+++ b/sensu-plugins-graphite.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'array_stats',      '0.6.0'
   s.add_runtime_dependency 'ipaddress',        '0.8.0'
   s.add_runtime_dependency 'rest-client',      '1.8.0'
-  s.add_runtime_dependency 'sensu-plugin',     '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',     '~> 2.0'
   s.add_runtime_dependency 'simple-graphite',  '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

This pull-request is intended to address bug #61 

Prior to the change, when trying to run the Graphite mutator, or any function, the following stack trace would get thrown
```
/opt/sensu/embedded/bin/handler-graphite-notify.rb --help
/opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:2278:in `check_version_conflict': can't activate json-1.8.6, already activated json-2.0.2 (Gem::LoadError)
	from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1404:in `activate'
	from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:89:in `block in require'
	from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:88:in `each'
	from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:88:in `require'
	from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-graphite-2.3.0/bin/mutator-graphite.rb:35:in `<top (required)>'
	from /opt/sensu/embedded/bin/mutator-graphite.rb:22:in `load'
	from /opt/sensu/embedded/bin/mutator-graphite.rb:22:in `<main>'
Exit 1
```

After the change, we get the expected data
```
/opt/sensu/embedded/bin//handler-graphite-notify.rb --help
Usage: ./handler-graphite-notify.rb (options)
    -j, --json_config JsonConfig     Config Name
```
#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

