### PR TITLE
Fix compatibility with newer versions of Graphite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Added -t flag to handler-graphite-event.rb to support post 1.0 versions of graphite which require tags sent as arrays.
 
 ## [3.0.0] - 2017-12-04
 ### Breaking Change

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -22,10 +22,9 @@ require 'uri'
 require 'json'
 
 class GraphiteEvent < Sensu::Handler
-
-  option :latest,
-         description: 'Latest - set for post 1.0 Graphite compatibility',
-         short: '-l',
+  option :tags_as_arrays,
+         description: 'send tags as array - for versions after 1.0 of graphite',
+         short: '-t',
          boolean: true,
          required: false,
          default: false
@@ -68,7 +67,7 @@ class GraphiteEvent < Sensu::Handler
 
     body = {
       'what' => 'sensu_event',
-      'tags' => config[:latest] ? [tags.join(',')] : tags.join(','),
+      'tags' => config[:tags_as_arrays] ? [tags.join(',')] : tags.join(','),
       'data' => event_status,
       'when' => Time.now.to_i
     }

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -23,8 +23,9 @@ require 'json'
 
 class GraphiteEvent < Sensu::Handler
   option :tags_as_arrays,
-         description: 'send tags as array - for graphite 1.0 or newer compatibility.',
+         description: 'send tags as array - for post graphite 1.0 compatibility.',
          short: '-t',
+         long: '--tags-as-arrays',
          boolean: true,
          required: false,
          default: false

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -22,7 +22,7 @@ require 'uri'
 require 'json'
 
 class GraphiteEvent < Sensu::Handler
-  option :tags_as_arrays,
+  option :tags_as_array,
          description: 'send tags as array - for post graphite 1.0 compatibility.',
          short: '-t',
          long: '--tags-as-array',

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -60,7 +60,7 @@ class GraphiteEvent < Sensu::Handler
 
     body = {
       'what' => 'sensu_event',
-      'tags' => tags.join(','),
+      'tags' => [tags.join(',')],
       'data' => event_status,
       'when' => Time.now.to_i
     }

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -23,7 +23,7 @@ require 'json'
 
 class GraphiteEvent < Sensu::Handler
   option :tags_as_arrays,
-         description: 'send tags as array - for versions after 1.0 of graphite',
+         description: 'send tags as array - for graphite 1.0 or newer compatibility.',
          short: '-t',
          boolean: true,
          required: false,

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -25,7 +25,7 @@ class GraphiteEvent < Sensu::Handler
   option :tags_as_arrays,
          description: 'send tags as array - for post graphite 1.0 compatibility.',
          short: '-t',
-         long: '--tags-as-arrays',
+         long: '--tags-as-array',
          boolean: true,
          required: false,
          default: false
@@ -68,7 +68,7 @@ class GraphiteEvent < Sensu::Handler
 
     body = {
       'what' => 'sensu_event',
-      'tags' => config[:tags_as_arrays] ? [tags.join(',')] : tags.join(','),
+      'tags' => config[:tags_as_array] ? [tags.join(',')] : tags.join(','),
       'data' => event_status,
       'when' => Time.now.to_i
     }

--- a/bin/handler-graphite-event.rb
+++ b/bin/handler-graphite-event.rb
@@ -22,6 +22,14 @@ require 'uri'
 require 'json'
 
 class GraphiteEvent < Sensu::Handler
+
+  option :latest,
+         description: 'Latest - set for post 1.0 Graphite compatibility',
+         short: '-l',
+         boolean: true,
+         required: false,
+         default: false
+
   def post_event(uri, body)
     uri          = URI.parse(uri)
     req          = Net::HTTP::Post.new(uri.path)
@@ -60,7 +68,7 @@ class GraphiteEvent < Sensu::Handler
 
     body = {
       'what' => 'sensu_event',
-      'tags' => [tags.join(',')],
+      'tags' => config[:latest] ? [tags.join(',')] : tags.join(','),
       'data' => event_status,
       'when' => Time.now.to_i
     }


### PR DESCRIPTION
## Pull Request Checklist

Fixes:
https://github.com/sensu-plugins/sensu-plugins-graphite/issues/63

Before: 

`{"command":"handler-graphite-event.rb","type":"pipe","filters":[],"severities":["ok","critical"],"handle_flapping":false,"handle_silenced":false,"name":"graphite_event"},"output":["{\"what\":\"sensu_event\",\"tags\":\"tag1,tag2,tag3\",\"data\":\"ok\",\"when\":{timestamp}}\n"]}`

After (with --tags-as-array):
`{"command":"handler-graphite-event.rb --tags-as-array","type":"pipe","filters":[],"severities":["ok","critical"],"handle_flapping":false,"handle_silenced":false,"name":"graphite_event"},"output":["{\"what\":\"sensu_event\",\"tags\":[\"tag1,tag2,tag3\"],\"data\":\"ok\",\"when\":{timestamp}}\n"]}`

After (without --tags-as array) -- No change from original behavior:
`{"command":"handler-graphite-event.rb","type":"pipe","filters":[],"severities":["ok","critical"],"handle_flapping":false,"handle_silenced":false,"name":"graphite_event"},"output":["{\"what\":\"sensu_event\",\"tags\":\"tag1,tag2,tag3\",\"data\":\"ok\",\"when\":{timestamp}}\n"]}`


#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues